### PR TITLE
Re-add content adapter for querying register

### DIFF
--- a/eea/annotator/browser/app/viewlet.py
+++ b/eea/annotator/browser/app/viewlet.py
@@ -2,10 +2,8 @@
 """
 from zope.component import getMultiAdapter
 from zope.component import queryAdapter
-from zope.component import queryUtility
 from zope.security import checkPermission
 from plone.app.layout.viewlets import common
-from plone.registry.interfaces import IRegistry
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.CMFCore.utils import getToolByName
 from eea.annotator.interfaces import IAnnotatorStorage
@@ -26,7 +24,7 @@ class Annotator(common.ViewletBase):
         """ Settings
         """
         if self._settings is None:
-            self._settings = queryUtility(IRegistry).forInterface(ISettings, None)
+            self._settings = ISettings(self.context)
         return self._settings
 
     @property
@@ -72,16 +70,6 @@ class Annotator(common.ViewletBase):
         return self.settings.noDuplicates or False
 
     @property
-    def disabled(self):
-        """ Check if inline comments are disabled for current context
-        """
-        context_type = getattr(self.context, 'portal_type', None)
-        enabled_types = self.settings.portalTypes if self.settings else None
-        if isinstance(enabled_types, list) and context_type in enabled_types:
-            return False
-        return True
-
-    @property
     def available(self):
         """ Available
         """
@@ -98,7 +86,8 @@ class Annotator(common.ViewletBase):
         if storage and storage.disabled:
             return False
 
-        if self.disabled:
+        settings = ISettings(self.context)
+        if settings.disabled:
             return False
 
         return True

--- a/eea/annotator/controlpanel/configure.zcml
+++ b/eea/annotator/controlpanel/configure.zcml
@@ -12,4 +12,10 @@
       permission="cmf.ManagePortal"
       />
 
+  <adapter
+      for="*"
+      provides="eea.annotator.interfaces.ISettings"
+      factory=".settings.ControlPanelAdapter"
+      />
+
 </configure>

--- a/eea/annotator/controlpanel/interfaces.py
+++ b/eea/annotator/controlpanel/interfaces.py
@@ -16,9 +16,8 @@ class ISettings(Interface):
     """ Settings
 
         >>> from eea.annotator.interfaces import ISettings
-        >>> ISettings(portal).portalTypes = [u'Document', u'News Item']
         >>> ISettings(portal).portalTypes
-        [u'Document', u'News Item']
+        [u'Document']
 
     """
     aform.widget('portalTypes', CheckBoxFieldWidget)

--- a/eea/annotator/portlets/annotator.py
+++ b/eea/annotator/portlets/annotator.py
@@ -4,22 +4,16 @@ from z3c.form import field
 from zope import schema
 from zope.component import getMultiAdapter
 from zope.component import queryAdapter
-from zope.component import queryUtility
 from zope.interface import implements
 from zope.security import checkPermission
-
 from plone.app.portlets.portlets import base
 try:
-    # Plone 4
-    from plone.app.portlets.browser import z3cformhelper as base_
+    from plone.app.portlets.browser import z3cformhelper as base_  # Plone 4
 except ImportError:
-    # Plone 5
-    base_ = base
+    base_ = base  # Plone 5
 from plone.portlets.interfaces import IPortletDataProvider
-from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-
 from eea.annotator.config import EEAMessageFactory as _
 from eea.annotator.controlpanel.interfaces import ISettings
 from eea.annotator.interfaces import IAnnotatorStorage
@@ -132,17 +126,6 @@ class Renderer(base.Renderer):
         return True
 
     @property
-    def disabled(self):
-        """ Check if inline comments are disabled for current context
-        """
-        context_type = getattr(self.context, 'portal_type', None)
-        settings = queryUtility(IRegistry).forInterface(ISettings, None)
-        enabled_types = settings.portalTypes if settings else None
-        if isinstance(enabled_types, list) and context_type in enabled_types:
-            return False
-        return True
-
-    @property
     def available(self):
         """By default, portlets are available on view view and edit view
         """
@@ -160,7 +143,8 @@ class Renderer(base.Renderer):
         if storage and storage.disabled:
             return False
 
-        if self.disabled:
+        settings = ISettings(self.context)
+        if settings.disabled:
             return False
 
         return True


### PR DESCRIPTION
Also updated the `controlpanel/interface.py` doctest because now we only need the adapter to act as a getter, not a setter.

Would you like me to move the test closer to the adapter, into `controlpanel/settings.py`?